### PR TITLE
Remove alignment definitions

### DIFF
--- a/Material.Icons.Avalonia/Material.Icons.Avalonia.csproj
+++ b/Material.Icons.Avalonia/Material.Icons.Avalonia.csproj
@@ -12,6 +12,7 @@
         <RepositoryUrl>https://github.com/AvaloniaUtils/Material.Icons.Avalonia.git</RepositoryUrl>
         <RepositoryType>Git</RepositoryType>
         <PackageTags>material icons material-design google-material avalonia</PackageTags>
+        <PackageVersion>1.0.1</PackageVersion>
     </PropertyGroup>
     <ItemGroup>
         <Compile Update="**\*.xaml.cs">

--- a/Material.Icons.Avalonia/MaterialIcon.xaml
+++ b/Material.Icons.Avalonia/MaterialIcon.xaml
@@ -7,8 +7,6 @@
         </Style.Resources>
         <Setter Property="Height" Value="16" />
         <Setter Property="Width" Value="16" />
-        <Setter Property="HorizontalAlignment" Value="Left" />
-        <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate>


### PR DESCRIPTION
In general case, alignments should be set to stretch. So I removed two lines of definitions alignments to let AvaloniaUI use Stretch in VerticalAlignment and HorizontalAlignment.